### PR TITLE
Increase disk size to 200GB

### DIFF
--- a/sdk-build-macos.pkr.hcl
+++ b/sdk-build-macos.pkr.hcl
@@ -12,7 +12,7 @@ source "tart-cli" "tart" {
   vm_name      = "sdk-build-macos"
   cpu_count    = 4
   memory_gb    = 8
-  disk_size_gb = 160
+  disk_size_gb = 200
   headless     = true
   ssh_password = "admin"
   ssh_username = "admin"


### PR DESCRIPTION
This commit increases the image disk size to 200GB because the previous size of 160GB is no longer sufficient for building Arm toolchain ...