### PR TITLE
Install Python 3.10

### DIFF
--- a/sdk-build-macos.pkr.hcl
+++ b/sdk-build-macos.pkr.hcl
@@ -54,7 +54,7 @@ build {
       "source ~/.zprofile",
       "brew install awscli autoconf automake binutils boost ccache coreutils",
       "brew install dos2unix dtc gawk gnu-sed gperf help2man meson ncurses",
-      "brew install ninja pkg-config python@3.8 texinfo",
+      "brew install ninja pkg-config python@3.10 texinfo",
     ]
   }
 }


### PR DESCRIPTION
This upgrades the Homebrew Python installation version from 3.8 to 3.10 because the SDK now links gdb-py against libpython3.10.